### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ env:
   global:
     - secure: "Q/psV9NDZnhCbavTrHAkcl3FTVQikOxcPL5M9juTu0+37hK7SB01iQPy5dzcdkRPbkQx5T9MKRToVcwSFkY09tQiDzSOpnFOlsREgtR40lErU/8Yxw5iCY3LLxkIUEP2YpgzsdFu5hqgXkK63Swowh4VmNh3fCnwf9oj8Att2Ck="
     - secure: "Xu+mVXYylMklhdZjYacN6d0PV/ATsNQZDRXRXoVCVk+VNicLL9hKhO2Knb9PJZZDtOEfE3yWxu9e+nnBjEi5yrPnNutMDGCC9EdE0V6s6GuZnPk1CowLmuP1Tqy9Qe/U9+dsEo1cRSQhGlNy6rjTYyd9MT74eRB7Uk2zi+jjMHw="
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
